### PR TITLE
add fix to mobile menu - no longer open by default.

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -52,11 +52,12 @@ function Header({ setInRoom, setShowHeader, userName, gamesWon }) {
         </ul>
           
         <div onClick={handleNav} className='text-cyan-400 block md:hidden'>
-          {!nav ? <AiOutlineClose size={20} /> : <AiOutlineMenu size={20} />}
+          {nav ? <AiOutlineClose size={20} /> : <AiOutlineMenu size={20} />}
         </div>
 
         {/* mobile menu */}
-        <div className={!nav ? 'fixed left-0 top-0 w-[60%] h-full border-r border-r-gray-900 bg-[#000300] ease-in-out duration-500' : 'fixed left-[-100%]'}>
+        <div className={ nav ? 'fixed left-0 top-0 w-[60%] h-full border-r border-r-gray-900 bg-[#000300] ease-in-out duration-500' : 'fixed left-[-100%]'}>
+        {/* <div > */}
           <div className="flex items-center m-5">
             <span  id="logo-nav-font" className="self-center text-4xl whitespace-nowrap text-sky-400/75 ">PHRAZ_L</span>
           </div>


### PR DESCRIPTION
## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? -->

This code fixes a bug where the mobile menu was open by default and hamburger button animation was flipped. 

## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria

<!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

<!-- If UI feature, take provide screenshots -->


### After

<!-- If UI feature, take provide screenshots -->

## Testing Steps / QA Criteria

<!-- Provide steps the other team members and mentors need to follow to properly test your additions. -->
